### PR TITLE
Fix string formatting of numbers outside int range

### DIFF
--- a/graalpython/com.oracle.graal.python/src/com/oracle/graal/python/runtime/formatting/StringFormatter.java
+++ b/graalpython/com.oracle.graal.python/src/com/oracle/graal/python/runtime/formatting/StringFormatter.java
@@ -15,6 +15,7 @@ import static com.oracle.graal.python.nodes.SpecialMethodNames.__STR__;
 import static com.oracle.graal.python.runtime.exception.PythonErrorType.TypeError;
 import static com.oracle.graal.python.runtime.exception.PythonErrorType.ValueError;
 
+import java.math.BigInteger;
 import java.util.function.BiFunction;
 
 import com.oracle.graal.python.builtins.objects.PNone;
@@ -387,10 +388,10 @@ public class StringFormatter {
                         fi.format((Integer) argAsNumber);
                     } else if (argAsNumber instanceof Long) {
                         f = fi = new IntegerFormatter.Traditional(core, buffer, spec);
-                        fi.format(((Long) argAsNumber).intValue());
+                        fi.format((BigInteger.valueOf((Long) argAsNumber)));
                     } else if (argAsNumber instanceof PInt) {
                         f = fi = new IntegerFormatter.Traditional(core, buffer, spec);
-                        fi.format(((PInt) argAsNumber).intValue());
+                        fi.format(((PInt) argAsNumber).getValue());
                     } else if (arg instanceof String && ((String) arg).length() == 1) {
                         f = ft = new TextFormatter(core, buffer, spec);
                         ft.format((String) arg);


### PR DESCRIPTION
Prior to this patch, string '%' formatting would produce incorrect
results on numbers outside the 32-bit integer range. Before formatting
these values the StringFormatter would convert the values down to ints.
This could produce disasterous results, especially in the case of UUIDs
which use percent formatting in their __str__ function and so could only
produce 2**32 values (half the time negative, and so not even validly
formatted UUID).

To fix this, we can format these values as BigIntegers. This will have
some performance impact, but can be optimized later by introducing a
code path to format primative long values and possibly by conditionally
down-casting BigIntegers to ints or longs when safe to use those
(presumedly faster) code paths.