### PR TITLE
Fix os.urandom to return uniform first byte

### DIFF
--- a/graalpython/com.oracle.graal.python/src/com/oracle/graal/python/builtins/modules/PosixModuleBuiltins.java
+++ b/graalpython/com.oracle.graal.python/src/com/oracle/graal/python/builtins/modules/PosixModuleBuiltins.java
@@ -1691,11 +1691,9 @@ public class PosixModuleBuiltins extends PythonBuiltins {
         @Specialization
         @TruffleBoundary(allowInlining = true)
         PBytes urandom(int size) {
-            // size is in bytes
-            BigInteger bigInteger = new BigInteger(size * 8, new Random());
-            // sign may introduce an extra byte
-            byte[] range = Arrays.copyOfRange(bigInteger.toByteArray(), 0, size);
-            return factory().createBytes(range);
+            byte[] bytes = new byte[size];
+            new Random().nextBytes(bytes);
+            return factory().createBytes(bytes);
         }
     }
 


### PR DESCRIPTION
The former implementation of os.urandom generated an N-byte random
BigInteger and got its contents as a byte array. However, because the
byte array returned by a BigInteger can have one additional byte to
account for the sign it truncated the array to only the first N bytes.

This causes a big problem with the first byte; any time the high bit of
the first byte would have been a 1, it would instead make the entire
first byte 0.

I've rewritten the urandom function not to use a BigInteger and instead
use the Random.nextBytes function. This both fixes the bug and likely
makes the code faster because it removes the array-copy needed to
truncate the array.